### PR TITLE
Fix in-place sed invocations

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -4,11 +4,7 @@ npx mitosis compile --force -t liquid --out=./src/_generated/_block.liquid -- sr
 npx mitosis compile --force -t react --out=./src/_generated/block.js -- src/block.mitosis.js
 
 # The compiler is still buggy so we have to help it a little bit
-sed -i -e 's/import { useLocalObservable/import { observer, useLocalObservable/g' src/_generated/block.js
-sed -i -e 's/?.map((item)/?.map((item, i)/g' src/_generated/block.js
-sed -i -e 's/export default //g' src/_generated/block.js
+sed -i '' -e 's/import { useLocalObservable/import { observer, useLocalObservable/g' src/_generated/block.js
+sed -i '' -e 's/?.map((item)/?.map((item, i)/g' src/_generated/block.js
+sed -i '' -e 's/export default //g' src/_generated/block.js
 echo "export default observer(TodoList);" >> src/_generated/block.js
-
-# Not sure why this file gets generated, possibly because we use --force to
-# overwrite the generated template. Regardless, we can just remove it.
-rm src/_generated/block.js-e


### PR DESCRIPTION
From memory, this is one of those discrepancies between BSD and GNU `sed`. Basically, BSD's `-i` option expects an extension with which `sed` will keep backups of the modified files. It needs to be explicitly passed a zero-length value if we want it to not produce backup files. What was happening before was that `sed` was consuming the next flag, `-e`, as the extension.

cc @michalczaplinski 